### PR TITLE
Revise and expand d20minor rulebook

### DIFF
--- a/d20minor.md
+++ b/d20minor.md
@@ -27,19 +27,26 @@ Every character has six abilities, which describe their strengths and weaknesses
 
 Each ability has a **modifier**, a number that you add to your d20 rolls. A modifier can be negative, zero, or positive. For example, if you have a Strength modifier of +2, you are pretty strong!
 
-## Advantage and Disadvantage
+## Ability Checks
 
-Sometimes, you'll have **advantage** on a roll. This means you get to roll two d20s and take the higher result! This happens when you have help, or the situation is in your favor.
+Sometimes, you'll want to do something that requires a special talent, like picking a lock, climbing a sheer wall, or convincing a guard to let you pass. Other times, you'll need to resist something bad, like a trap, a poison, or a magical spell. In these situations, you'll make an **Ability Check**.
 
-Other times, you'll have **disadvantage**. This means you roll two d20s and take the lower result. This happens when something is making the task harder for you.
+Making an Ability Check is simple. Just like the core rule, you:
 
-## Skill Checks
+*   **Roll a d20.**
+*   **Add the modifier for the ability that makes the most sense.** For example, climbing a wall would be a Strength check, while resisting a poison would be a Constitution check. The GM will tell you which ability to use.
+*   **Compare the total to a Difficulty Class (DC).**
 
-When you want to do something that requires a particular skill, like picking a lock or climbing a wall, you make a **skill check**. This is just like the core rule: roll a d20 and add the modifier for the ability that makes the most sense. For example, to climb a wall, you'd use your Strength modifier.
+If your total is equal to or higher than the DC, you succeed!
 
-## Saving Throws
+### Attacking
 
-Sometimes, you need to resist something bad, like a trap, a poison, or a spell. This is called a **saving throw**. It's like a skill check, but you're trying to avoid something bad happening to you. For example, if you step on a poison dart trap, you might need to make a Constitution saving throw to see if you resist the poison.
+Attacking a creature is a special kind of Ability Check.
+
+*   **For melee attacks** (with swords, axes, etc.), you make a **Strength check**.
+*   **For ranged attacks** (with bows, thrown daggers, etc.), you make a **Dexterity check**.
+
+Instead of comparing your roll to a DC, you compare it to the creature's **Armor Class (AC)**. If you hit, you deal damage!
 
 ## Character Classes
 
@@ -47,54 +54,123 @@ Every character has a class, which is like their job or archetype. Your class gi
 
 ### Fighter
 
-Fighters are brave warriors who are skilled with all kinds of weapons and armor.
+*Fighters are brave warriors who are skilled with all kinds of weapons and armor.*
 
-*   **Hit Points:** 10 + your Constitution modifier.
-*   **Weapon and Armor:** Fighters can use any weapon and wear any armor.
-*   **Special Ability: Extra Attack.** At 2nd level, you can make two attacks on your turn instead of one.
+*   **Hit Points:** 10 + your Constitution modifier
+*   **Weapon & Armor:** Can use any weapon and wear any armor.
 
-**Fighter Progression**
 | Level | Special |
 |---|---|
-| 1 | You are a brave fighter. |
-| 2 | Extra Attack. |
-| 3 | You get +1 to all your attack rolls. |
-| 4 | You can add +1 to any ability modifier. |
-| 5 | You get another +1 to all your attack rolls. |
-
-### Wizard
-
-Wizards are powerful spellcasters who can bend reality to their will.
-
-*   **Hit Points:** 6 + your Constitution modifier.
-*   **Weapon and Armor:** Wizards can use simple weapons (like a staff or a dagger) but cannot wear armor.
-*   **Special Ability: Spellcasting.** Wizards can cast spells. They use their Intelligence for their spellcasting.
-
-**Wizard Progression**
-| Level | Special |
-|---|---|
-| 1 | You know two spells. |
-| 2 | You learn a new spell. |
-| 3 | You learn a new spell. |
-| 4 | You can add +1 to any ability modifier. |
-| 5 | You learn a new spell. |
+| 1 | Second Wind: Once per day, you can heal yourself for 1d10 HP. |
+| 2 | Action Surge: Once per day, you can take one extra action on your turn. |
+| 3 | Improved Critical: You now score a critical hit on a roll of 19 or 20. |
+| 4 | Ability Score Improvement: Add +1 to any ability modifier. |
+| 5 | Extra Attack: You can attack twice when you take the Attack action. |
+| 6 | Ability Score Improvement: Add +1 to any ability modifier. |
+| 7 | Remarkable Athlete: You can add your level to any Strength check. |
+| 8 | Ability Score Improvement: Add +1 to any ability modifier. |
+| 9 | Indomitable: Once per day, you can re-roll a failed ability check. |
+| 10 | Superior Critical: You now score a critical hit on a roll of 18, 19, or 20. |
 
 ### Rogue
 
-Rogues are sneaky and skilled characters who are good at getting into and out of trouble.
+*Rogues are sneaky and skilled characters who are good at getting into and out of trouble.*
 
-*   **Hit Points:** 8 + your Constitution modifier.
-*   **Weapon and Armor:** Rogues can use light weapons (like daggers and shortswords) and wear light armor.
-*   **Special Ability: Sneak Attack.** If you hit a creature that is surprised or that has one of your allies next to it, you can add 1d6 to your damage roll. This increases to 2d6 at 3rd level and 3d6 at 5th level.
+*   **Hit Points:** 8 + your Constitution modifier
+*   **Weapon & Armor:** Can use light weapons (daggers, shortswords) and wear light armor.
 
-**Rogue Progression**
 | Level | Special |
 |---|---|
-| 1 | Sneak Attack (1d6). |
-| 2 | You get advantage on Dexterity (Stealth) checks. |
-| 3 | Sneak Attack (2d6). |
-| 4 | You can add +1 to any ability modifier. |
-| 5 | Sneak Attack (3d6). |
+| 1 | Sneak Attack: Once per turn, if you have an ally next to your target, you can add 1d6 to your damage. |
+| 2 | Cunning Action: You can use your action to Dash or Hide. |
+| 3 | Sneak Attack: Your sneak attack damage increases to 2d6. |
+| 4 | Ability Score Improvement: Add +1 to any ability modifier. |
+| 5 | Uncanny Dodge: Once per day, you can halve the damage of an attack that hits you. |
+| 6 | Sneak Attack: Your sneak attack damage increases to 3d6. |
+| 7 | Evasion: When you make a Dexterity ability check to take only half damage from an effect, you instead take no damage if you succeed, and only half damage if you fail. |
+| 8 | Ability Score Improvement: Add +1 to any ability modifier. |
+| 9 | Sneak Attack: Your sneak attack damage increases to 4d6. |
+| 10 | Stroke of Luck: Once per day, you can turn a miss into a hit. |
+
+### Wizard
+
+*Wizards are powerful spellcasters who can bend reality to their will.*
+
+*   **Hit Points:** 6 + your Constitution modifier
+*   **Weapon & Armor:** Can use simple weapons (staff, dagger) but cannot wear armor.
+
+| Level | Special |
+|---|---|
+| 1 | Spellcasting: You know three spells. |
+| 2 | Arcane Recovery: Once per day, you can cast one extra spell. |
+| 3 | You learn a new spell. |
+| 4 | Ability Score Improvement: Add +1 to any ability modifier. |
+| 5 | You learn a new spell. |
+| 6 | Empowered Spells: Add your Intelligence modifier to the damage of your spells. |
+| 7 | You learn a new spell. |
+| 8 | Ability Score Improvement: Add +1 to any ability modifier. |
+| 9 | You learn a new spell. |
+| 10 | Spell Mastery: Choose one 1st-level spell. You can now cast it at will. |
+
+### Cleric
+
+*Clerics are holy warriors who wield divine magic.*
+
+*   **Hit Points:** 8 + your Constitution modifier
+*   **Weapon & Armor:** Can use simple weapons and wear all armor.
+
+| Level | Special |
+|---|---|
+| 1 | Spellcasting: You know two divine spells. |
+| 2 | Channel Divinity: Turn Undead. As an action, you can force all undead within 30 feet to make a Wisdom ability check against your spell DC. If they fail, they must move away from you. |
+| 3 | You learn a new divine spell. |
+| 4 | Ability Score Improvement: Add +1 to any ability modifier. |
+| 5 | You learn a new divine spell. |
+| 6 | Divine Strike: Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 radiant damage. |
+| 7 | You learn a new divine spell. |
+| 8 | Ability Score Improvement: Add +1 to any ability modifier. |
+| 9 | You learn a new divine spell. |
+| 10 | Divine Intervention: Once per week, you can ask your deity for help. The GM decides what happens. |
+
+### Bard
+
+*Bards are charismatic performers who use music and magic to inspire allies and hinder foes.*
+
+*   **Hit Points:** 8 + your Constitution modifier
+*   **Weapon & Armor:** Can use simple weapons and wear light armor.
+
+| Level | Special |
+|---|---|
+| 1 | Spellcasting: You know two bard spells. |
+| 2 | Bardic Inspiration: As an action, you can inspire a creature. Once within the next 10 minutes, the creature can roll a d6 and add the number rolled to one ability check it makes. |
+| 3 | You learn a new bard spell. |
+| 4 | Ability Score Improvement: Add +1 to any ability modifier. |
+| 5 | You learn a new bard spell. |
+| 6 | Countercharm: As an action, you can start a performance that gives your allies a +2 bonus to ability checks to resist being frightened or charmed. |
+| 7 | You learn a new bard spell. |
+| 8 | Ability Score Improvement: Add +1 to any ability modifier. |
+| 9 | You learn a new bard spell. |
+| 10 | Magical Secrets: You can learn two spells from any class. |
+
+### Ranger
+
+*Rangers are skilled hunters and trackers who are at home in the wilderness.*
+
+*   **Hit Points:** 10 + your Constitution modifier
+*   **Weapon & Armor:** Can use all weapons and wear all armor.
+
+| Level | Special |
+|---|---|
+| 1 | Favored Enemy: You have a +2 bonus to damage rolls against one type of creature (e.g., goblins, undead). |
+| 2 | Archery: You gain a +2 bonus to attack rolls you make with ranged weapons. |
+| 3 | Primal Awareness: You can speak with animals. |
+| 4 | Ability Score Improvement: Add +1 to any ability modifier. |
+| 5 | Extra Attack: You can attack twice when you take the Attack action. |
+| 6 | Ability Score Improvement: Add +1 to any ability modifier. |
+| 7 | Natural Explorer: You are an expert tracker. |
+| 8 | Ability Score Improvement: Add +1 to any ability modifier. |
+| 9 | Vanish: You can Hide as a free action on your turn. |
+| 10 | Feral Senses: You can detect the location of any invisible creature within 30 feet of you. |
 
 ## Character Races
 
@@ -102,21 +178,82 @@ Every character also has a race, which describes what kind of creature they are.
 
 ### Human
 
-Humans are adaptable and ambitious. They are the most common race in the world.
+*Humans are adaptable and ambitious. They are the most common race in the world.*
 
 *   **Special Ability: Adaptable.** You can add +1 to any two different ability modifiers.
 
 ### Elf
 
-Elves are graceful and long-lived. They are at home in the forests and wild places of the world.
+*Elves are graceful and long-lived. They are at home in the forests and wild places of the world.*
 
-*   **Special Ability: Keen Senses.** You have advantage on Wisdom (Perception) checks to notice things.
+*   **Special Ability: Fey Ancestry.** You have a +2 bonus on ability checks to resist being charmed.
 
 ### Dwarf
 
-Dwarves are stout and hardy folk who are at home in the mountains and underground.
+*Dwarves are stout and hardy folk who are at home in the mountains and underground.*
 
 *   **Special Ability: Toughness.** Your hit point maximum increases by 1 for every level you have.
+
+### Halfling
+
+*Halflings are small, cheerful folk who are surprisingly lucky.*
+
+*   **Special Ability: Lucky.** When you roll a 1 on a d20 for an ability check, you can re-roll the die and must use the new roll.
+
+### Half-Orc
+
+*Half-orcs are strong and tough, with a bit of orcish blood.*
+
+*   **Special Ability: Savage Attacks.** When you score a critical hit with a melee weapon attack, you can roll one of the weapon’s damage dice one additional time and add it to the extra damage of the critical hit.
+
+## Equipment
+
+Adventurers need good gear. This section describes some of the most common equipment.
+
+### Armor
+
+Armor helps protect you from attacks. The better the armor, the higher your Armor Class (AC).
+
+| Armor | Armor Class |
+|---|---|
+| Light Armor (Leather) | 11 + Dexterity modifier |
+| Medium Armor (Chain Shirt) | 13 + Dexterity modifier (max +2) |
+| Heavy Armor (Plate) | 18 |
+| Shield | +2 to AC |
+
+### Weapons
+
+Every adventurer needs a trusty weapon. Here are a few to choose from.
+
+| Weapon | Damage | Properties |
+|---|---|---|
+| Dagger | 1d4 piercing | Light, thrown |
+| Shortsword | 1d6 piercing | Light |
+| Longsword | 1d8 slashing | - |
+| Greatsword | 1d12 slashing | Two-handed |
+| Handaxe | 1d6 slashing | Light, thrown |
+| Battleaxe | 1d8 slashing | - |
+| Greataxe | 1d12 slashing | Two-handed |
+| Shortbow | 1d6 piercing | Two-handed, ranged |
+| Longbow | 1d8 piercing | Two-handed, ranged |
+
+### Adventuring Gear
+
+Here are a few other things you might need on your adventures.
+
+*   **Backpack:** To carry your stuff.
+*   **Rope:** 50 feet of rope. You never know when you'll need it.
+*   **Torches (10):** To light up dark places.
+*   **Rations (3 days):** Food for the road.
+*   **Waterskin:** To carry water.
+
+### Magic Items
+
+Magic items are rare and powerful. Here are a few examples.
+
+*   ***+1 Sword:*** This sword is magical. You get a +1 bonus to attack and damage rolls made with it.
+*   ***Potion of Healing:*** When you drink this potion, you regain 2d4+2 hit points.
+*   ***Boots of Elvenkind:*** Your steps make no sound. You can move silently.
 
 ## Combat
 
@@ -136,19 +273,13 @@ You can move before or after your action.
 
 ### Actions
 
-Here are the most common actions you can take:
+On your turn, you can take one **Action**. This can be anything from attacking a monster to casting a spell to trying to pick a lock.
 
-*   **Attack:** Make an attack against a creature.
-*   **Dash:** You can move up to your speed again.
-*   **Use an Object:** You can drink a potion, open a door, or do something else that requires your attention.
-
-### Making an Attack
-
-To attack, you roll a d20 and add your Strength modifier for melee attacks (with swords, axes, etc.) or your Dexterity modifier for ranged attacks (with bows, etc.).
-
-*   If your total is equal to or higher than the target's **Armor Class (AC)**, you hit!
-*   If you roll a 20 on the d20, it's a **critical hit**! You roll double the damage dice.
-*   If you roll a 1 on the d20, you miss.
+The most common actions are:
+*   **Attack:** Make a melee or ranged attack against a creature.
+*   **Cast a Spell:** Cast a spell that you know.
+*   **Dash:** Move up to your speed again.
+*   **Use an Object:** Drink a potion, open a door, or something similar.
 
 ### Damage and Hit Points
 
@@ -162,56 +293,179 @@ When your HP drops to 0, you are **knocked out**. You fall down and can't do any
 
 Another character can use their action to help you. If they do, you get 1 HP back and can act normally on your next turn.
 
+## Experience Points
+
+As you defeat monsters and overcome challenges, you will gain **Experience Points (XP)**. When you get enough XP, you **level up**!
+
+When you level up, you get more powerful. You get more hit points, and you might learn new abilities. Check your class description to see what you get when you level up.
+
+The GM will tell you when you get XP. You get XP for defeating monsters, and the GM can also give you XP for good ideas, brave actions, or for making the game fun for everyone.
+
+**Experience Points by Level**
+| Level | Experience Points Needed |
+|---|---|
+| 2 | 300 |
+| 3 | 900 |
+| 4 | 2,700 |
+| 5 | 6,500 |
+
 ## Magic
 
-Magic is a powerful force in the world of d20minor. Wizards are the most common magic-users, but other creatures and even some items can have magical properties.
+Magic is a powerful force in the world of d20minor. Wizards, Clerics, and Bards can all cast spells.
 
 ### Casting Spells
 
-To cast a spell, a wizard must use their action. Some spells require the wizard to make an attack roll, while others force a creature to make a saving throw.
+To cast a spell, a character must use their action. Some spells require an attack roll, while others force a creature to make an ability check to resist the spell's effect.
 
-*   **Spell Attack:** If a spell requires an attack roll, the wizard rolls a d20 and adds their Intelligence modifier. If the total equals or exceeds the target's AC, the spell hits.
-*   **Spell DC:** If a spell requires a saving throw, the DC is **10 + the wizard's Intelligence modifier**.
+*   **Spell Attack:** If a spell requires an attack roll, the caster rolls a d20 and adds their spellcasting ability modifier. If the total equals or exceeds the target's AC, the spell hits.
+*   **Spell DC:** If a spell requires a creature to make an ability check to resist it, the DC is **10 + the caster's spellcasting ability modifier**.
 
-### Spells
+Your spellcasting ability depends on your class:
+*   **Wizards** use Intelligence.
+*   **Clerics** use Wisdom.
+*   **Bards** use Charisma.
 
-Here are a few spells a wizard can learn.
+### Wizard Spells
 
+*   **Burning Hands:** You spew fire from your hands. Each creature in a 15-foot cone must make a Dexterity ability check. On a failed check, a creature takes 3d6 fire damage. On a successful check, the creature takes half as much damage.
+*   **Charm Person:** You try to charm a humanoid you can see. It must make a Wisdom ability check, and does so with a +5 bonus if you or your companions are fighting it. If it fails, it is charmed by you for one hour or until you or your companions do anything harmful to it. The charmed creature regards you as a friendly acquaintance.
+*   **Detect Magic:** For 10 minutes, you can sense the presence of magic within 30 feet of you. You know the location of any magical object or effect.
 *   **Fire Bolt:** You hurl a mote of fire at a creature. Make a spell attack. On a hit, the target takes 1d10 fire damage.
+*   **Identify:** You can determine the properties of a magic item.
+*   **Invisibility:** You become invisible for one hour. The spell ends if you attack or cast a spell.
 *   **Light:** You touch an object, and it glows with light, as bright as a torch, for one hour.
 *   **Magic Missile:** You create three magical darts that automatically hit one or more creatures you can see. Each dart does 1d4+1 force damage.
+*   **Mage Armor:** You touch a willing creature who isn't wearing armor, and a protective magical force surrounds it until the spell ends. The target's base AC becomes 13 + its Dexterity modifier. The spell ends if the target dons armor or if you dismiss the spell as an action.
 *   **Shield:** You create a magical barrier around yourself. Until your next turn, you gain +5 to your AC.
-*   **Sleep:** You put creatures to sleep. Roll 5d8. The total is how many hit points of creatures you can affect. You start with the creature with the lowest current hit points, and if you have enough "sleep" to affect them, they fall unconscious. You then move to the next lowest, and so on.
-*   **Thunderwave:** You create a wave of thunderous force. Each creature in a 15-foot cube originating from you must make a Constitution saving throw. On a failed save, a creature takes 2d8 thunder damage and is pushed 10 feet away from you. On a successful save, the creature takes half as much damage and is not pushed.
+*   **Sleep:** You put creatures to sleep. Roll 5d8. The total is how many hit points of creatures you can affect. You start with the creature with the lowest current hit points, and if you have enough "sleep" to affect them, they fall unconscious.
+*   **Thunderwave:** You create a wave of thunderous force. Each creature in a 15-foot cube originating from you must make a Constitution ability check. On a failed check, a creature takes 2d8 thunder damage and is pushed 10 feet away from you. On a successful check, the creature takes half as much damage and is not pushed.
+
+### Cleric Spells
+
+*   **Bless:** You bless up to three creatures of your choice within range. For one minute, whenever a target makes an ability check, they can roll a d4 and add the number rolled to the check.
+*   **Cure Wounds:** A creature you touch regains 1d8 + your spellcasting ability modifier hit points.
+*   **Guiding Bolt:** You hurl a bolt of light at a creature. Make a spell attack. On a hit, the target takes 4d6 radiant damage, and the next attack made against this target has a +5 bonus.
+*   **Sanctuary:** You ward a creature within range against attack. For one minute, any creature who targets the warded creature with an attack or a harmful spell must first make a Wisdom ability check against your spell DC. On a failed check, the creature must choose a new target or lose the attack or spell.
+*   **Spiritual Weapon:** You create a floating, spectral weapon. For one minute, you can use your action to make a melee spell attack against a creature within 5 feet of the weapon. On a hit, the target takes 1d8 + your spellcasting ability modifier force damage.
+
+### Bard Spells
+
+*   **Charm Person:** You try to charm a humanoid you can see. It must make a Wisdom ability check against your spell DC. If it fails, it is charmed by you for one hour or until you or your companions do anything harmful to it. The charmed creature regards you as a friendly acquaintance.
+*   **Dissonant Whispers:** You whisper a discordant melody that only one creature of your choice within range can hear, wracking it with terrible pain. The target must make a Wisdom ability check against your spell DC. On a failed check, it takes 3d6 psychic damage and must immediately move as far as its speed allows away from you.
+*   **Healing Word:** A creature of your choice that you can see within range regains hit points equal to 1d4 + your spellcasting ability modifier.
+*   **Sleep:** You put creatures to sleep. Roll 5d8. The total is how many hit points of creatures you can affect. You start with the creature with the lowest current hit points, and if you have enough "sleep" to affect them, they fall unconscious.
+*   **Vicious Mockery:** You unleash a string of insults laced with subtle enchantments at a creature you can see within range. If the target can hear you, it must succeed on a Wisdom ability check or take 1d4 psychic damage and have a -2 penalty to its next attack roll.
 
 ## Monsters
 
-What's an adventure without monsters? Here are a few creatures for the GM to use.
+What's an adventure without monsters? Here are a few creatures for the GM to use. The "Level" of a monster gives you a rough idea of how challenging it is. A party of four adventurers should be able to handle a monster of their own level.
 
-### Goblin
+### Giant Rat (Level 1)
+*   **AC:** 12
+*   **HP:** 7
+*   **Attack:** Bite (+4 to hit, 1d4+2 piercing damage)
 
-*Goblins are small, nasty creatures that live in caves and ruins.*
-
-*   **Armor Class:** 15
-*   **Hit Points:** 7
+### Goblin (Level 1)
+*   **AC:** 15
+*   **HP:** 7
 *   **Attack:** Shortsword (+4 to hit, 1d6+2 piercing damage)
 
-### Orc
+### Skeleton (Level 1)
+*   **AC:** 13
+*   **HP:** 13
+*   **Attack:** Shortsword (+4 to hit, 1d6+2 piercing damage)
 
-*Orcs are big, brutish humanoids who love to fight.*
+### Wolf (Level 1)
+*   **AC:** 13
+*   **HP:** 11
+*   **Attack:** Bite (+4 to hit, 2d4+2 piercing damage)
 
-*   **Armor Class:** 13
-*   **Hit Points:** 15
+### Zombie (Level 1)
+*   **AC:** 8
+*   **HP:** 22
+*   **Attack:** Slam (+3 to hit, 1d6+1 bludgeoning damage)
+
+### Orc (Level 2)
+*   **AC:** 13
+*   **HP:** 15
 *   **Attack:** Greataxe (+5 to hit, 1d12+3 slashing damage)
 
-### Young Dragon
+### Owlbear (Level 3)
+*   **AC:** 13
+*   **HP:** 59
+*   **Attack:** Beak (+7 to hit, 1d10+5 piercing damage) and Claws (+7 to hit, 2d8+5 slashing damage)
 
-*Even a young dragon is a fearsome opponent.*
+### Bugbear (Level 3)
+*   **AC:** 16
+*   **HP:** 27
+*   **Attack:** Morningstar (+4 to hit, 2d8+2 piercing damage)
 
-*   **Armor Class:** 18
-*   **Hit Points:** 133
+### Ghoul (Level 4)
+*   **AC:** 12
+*   **HP:** 22
+*   **Attack:** Bite (+2 to hit, 2d6+2 piercing damage) and Claws (+4 to hit, 2d4+2 slashing damage). A creature hit by a ghoul's attack must make a DC 10 Constitution ability check or be paralyzed for 1 minute.
+
+### Ogre (Level 4)
+*   **AC:** 11
+*   **HP:** 59
+*   **Attack:** Greatclub (+6 to hit, 2d8+4 bludgeoning damage)
+
+### Troll (Level 5)
+*   **AC:** 15
+*   **HP:** 84
+*   **Attack:** Bite (+7 to hit, 1d6+5 piercing damage) and two Claw attacks (+7 to hit, 2d6+5 slashing damage)
+*   **Special:** The troll regains 10 hit points at the start of its turn. If the troll takes acid or fire damage, this trait doesn't function at the start of the troll's next turn. The troll dies only if it starts its turn with 0 hit points and doesn't regenerate.
+
+### Vampire Spawn (Level 5)
+*   **AC:** 15
+*   **HP:** 82
+*   **Attack:** Bite (+6 to hit, 1d6+3 piercing damage plus 2d6 necrotic damage)
+*   **Special:** The vampire regains 10 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water.
+
+### Wraith (Level 5)
+*   **AC:** 13
+*   **HP:** 67
+*   **Attack:** Life Drain (+6 to hit, 4d8+3 necrotic damage). The target must succeed on a DC 14 Constitution ability check or its hit point maximum is reduced by an amount equal to the damage taken.
+
+### Manticore (Level 6)
+*   **AC:** 14
+*   **HP:** 68
+*   **Attack:** Bite (+5 to hit, 1d8+3 piercing damage) and two Claw attacks (+5 to hit, 1d6+3 slashing damage)
+*   **Special:** Tail Spike. Ranged Weapon Attack: +5 to hit, range 100/200 ft., one target. Hit: 1d8+3 piercing damage.
+
+### Minotaur (Level 6)
+*   **AC:** 14
+*   **HP:** 76
+*   **Attack:** Greataxe (+6 to hit, 2d12+4 slashing damage)
+*   **Special:** Charge. If the minotaur moves at least 10 feet straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 2d8 piercing damage.
+
+### Fire Giant (Level 9)
+*   **AC:** 18
+*   **HP:** 162
+*   **Attack:** Greatsword (+11 to hit, 6d6+7 slashing damage)
+
+### Young Dragon (Level 10)
+*   **AC:** 18
+*   **HP:** 133
 *   **Attack:** Bite (+7 to hit, 2d10+4 piercing damage)
-*   **Special: Fire Breath.** The dragon breathes fire in a 15-foot cone. Everyone in the cone must make a DC 15 Dexterity saving throw, taking 6d6 fire damage on a failed save, or half as much on a successful one. The dragon can't use its fire breath again for a minute.
+*   **Special:** Fire Breath. The dragon breathes fire in a 15-foot cone. Everyone in the cone must make a DC 15 Dexterity ability check, taking 6d6 fire damage on a failed check, or half as much on a successful one. The dragon can't use its fire breath again for a minute.
+
+### Frost Giant (Level 10)
+*   **AC:** 15
+*   **HP:** 138
+*   **Attack:** Greataxe (+9 to hit, 3d12+6 slashing damage)
+
+### Hydra (Level 10)
+*   **AC:** 15
+*   **HP:** 172
+*   **Attack:** Bite (+8 to hit, 1d10+5 piercing damage). The hydra has five heads. It can make one bite attack for each head.
+*   **Special:** At the end of its turn, it grows two heads for each of its heads that died since its last turn, unless it has taken fire damage since its last turn.
+
+### Vampire (Level 15)
+*   **AC:** 16
+*   **HP:** 144
+*   **Attack:** Bite (+9 to hit, 1d6+4 piercing damage plus 3d6 necrotic damage)
+*   **Special:** The vampire regains 20 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of the vampire's next turn.
 
 ## Gamemastering
 


### PR DESCRIPTION
This commit revises and expands the `d20minor.md` file based on user feedback.

The following changes were made:
- The core rules were simplified by removing Advantage/Disadvantage and unifying Skill Checks and Saving Throws into a single "Ability Check" mechanic.
- Rules for Experience Points and leveling up were added.
- The number of character classes was expanded to six (Fighter, Rogue, Wizard, Cleric, Bard, Ranger) and the level progression was extended to 10 levels.
- The number of character races was expanded to five (Human, Elf, Dwarf, Halfling, Half-Orc).
- A new section for Equipment and Weapons was added, including a small selection of magical items.
- The Magic section was expanded with more spells and separate spell lists for Clerics and Bards.
- The Bestiary was expanded to include 20 monsters, each with a monster level.
- The entire document was reviewed for clarity, consistency, and completeness.